### PR TITLE
fix for error: no bin target named `spin-wait`

### DIFF
--- a/mdbook/src/06-hello-world/spin-wait.md
+++ b/mdbook/src/06-hello-world/spin-wait.md
@@ -8,7 +8,7 @@ Well, here's the dumb way. It's not good, but it's a start. Take a look at `exam
 {{#include examples/spin-wait.rs}}
 ```
 
-Run this with `cargo run --release --bin spin-wait` — the `--release` is really important here — and
+Run this with `cargo run --release --example spin-wait` — the `--release` is really important here — and
 you should see the LED on your MB2 flash on and off *about* once per second.
 
 Things you might be wondering:


### PR DESCRIPTION
**Disclaimer:** I am not certain whether this is actually an issue or simply my incapacity to properly follow the guide. :sweat_smile: 

In the subsection _06-hello-world/spin-wait_ trying to execute `cargo run --release --bin spin-wait` failed:

```error: no bin target named `spin-wait`.
Available bin targets:
    hello-world```

However, the execution with the flag `--example` instead of `--bin` works.