### PR TITLE
minor fixes: moving a formula and updating outdated references

### DIFF
--- a/mdbook/src/12-led-compass/magnitude.md
+++ b/mdbook/src/12-led-compass/magnitude.md
@@ -6,20 +6,17 @@ only thing we have to compute in order to get the magnitude of the magnetic fiel
 the magnitude of the 3D vector that our `x` `y` `z` values describe. As you might remember from
 school this is simply:
 
+``` rust
+use libm::sqrtf;
+let magnitude = sqrtf(x * x + y * y + z * z);
+```
+
 [`magnetic_field()`]: https://docs.rs/lsm303agr/1.1.0/lsm303agr/struct.Lsm303agr.html#method.magnetic_field
 
 Rust does not have floating-point math functions such as `sqrtf()` in `core`, so our `no_std`
 program has to get an implementation from somewhere. We use the [libm] crate for this.
 
 [libm]: https://crates.io/crates/libm
-
-``` rust
-use libm::sqrtf;
-let magnitude = sqrtf(x * x + y * y + z * z);
-```
-
-
-
 
 Putting all this together in a program (`examples/magnitude.rs`):
 

--- a/mdbook/src/12-led-compass/magnitude.md
+++ b/mdbook/src/12-led-compass/magnitude.md
@@ -24,7 +24,7 @@ Putting all this together in a program (`examples/magnitude.rs`):
 {{#include examples/magnitude.rs}}
 ```
 
-Run this with `cargo run --bin magnitude`.
+Run this with `cargo run --example magnitude`.
 
 This program will report the magnitude (strength) of the magnetic field in nanotesla (`nT`) and
 milligauss (`mG`, where 1 `mG` = 100 `nT`). The magnitude of the Earth's magnetic field is in the

--- a/mdbook/src/appendix/3-mag-calibration/README.md
+++ b/mdbook/src/appendix/3-mag-calibration/README.md
@@ -39,7 +39,7 @@ You have to tilt the micro:bit until all the LEDs on the LED matrix light up. Th
 shows the current target LED.
 
 Note that the calibration matrix is printed by the demo program. This matrix can be hard-coded into
-a program such as the [chapter 9] compass program (or stored in flash somewhere somehow) to avoid
+a program such as the [chapter 12] compass program (or stored in flash somewhere somehow) to avoid
 the need to recalibrate every time the user runs the program.
 
-[chapter 9]: ../../12-led-compass/index.html
+[chapter 12]: ../../12-led-compass/index.html

--- a/mdbook/src/explore.md
+++ b/mdbook/src/explore.md
@@ -29,7 +29,7 @@ In preemptive multitasking a task that's currently being executed can, at any po
 *preempted* (interrupted) by another task. On preemption, the first task will be suspended and the
 processor will instead execute the second task. At some point the first task will be resumed.
 Microcontrollers provide hardware support for preemption in the form of *interrupts*. We were
-introduced to interrupts when we built our snake game in chapter 11.
+introduced to interrupts when we built our snake game in [chapter 14](14-snake-game/index.md).
 
 In cooperative multitasking a task that's being executed will run until it reaches a *suspension
 point*. When the processor reaches that suspension point it will stop executing the current task and

--- a/mdbook/src/explore.md
+++ b/mdbook/src/explore.md
@@ -76,10 +76,7 @@ the near future.
 
 ### Interrupts
 
-We saw button interrupts briefly in [chapter 11].
-
-[chapter 11](14-snake-game/controls.html)
-
+We saw button interrupts briefly in [chapter 14](14-snake-game/controls.html).
 This introduced the key idea: in order to interact with the real world, it is often necessary for
 the microcontroller to respond *immediately* when some kind of event occurs.
 


### PR DESCRIPTION
The placement of the formula at the beginning of chapter 12.1. seems a little off for me in regard to ending the first paragraph by _"As you might remember from school this is simply:"_ and being immediately followed by the next paragraph.

![magnitude_old](https://github.com/user-attachments/assets/c5bde7f8-fd1c-4998-9752-7bdf53353101)

I would suggest moving the formula up accordingly.

![magnitude_new](https://github.com/user-attachments/assets/c6c2da83-8bca-4833-8648-69d00c6e9abf)
