### PR TITLE
updated github actions to current version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   build-book-code:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -26,7 +26,7 @@ jobs:
   build-book-doc:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -40,7 +40,7 @@ jobs:
   build-book:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -54,11 +54,13 @@ jobs:
         run: echo "~/.local/bin" >> $GITHUB_PATH
 
       - name: Cache Cargo installed binaries
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         id: cache-cargo
         with:
           path: ~/cargo-bin
-          key: cache-cargo
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
 
       - name: Install mdbook
         if: steps.cache-cargo.outputs.cache-hit != 'true'


### PR DESCRIPTION
This brings the github actions in CI for this repo up to v4. It does nothing for `actions-rs`, which needs to be swapped out for something current.