### PR TITLE
Update .cargo/config.toml in setup to match .cargo/config.toml at the root of the book

### DIFF
--- a/mdbook/src/03-setup/.cargo/config.toml
+++ b/mdbook/src/03-setup/.cargo/config.toml
@@ -5,4 +5,5 @@ target = "thumbv7em-none-eabihf"
 runner = "probe-rs run --chip nRF52833_xxAA"
 rustflags = [
   "-C", "linker=rust-lld",
+  "-C", "link-arg=-Tlink.x",
 ]


### PR DESCRIPTION
While the discovery book suggests you clone the book repo, I prefer working gradually and only copying files when I need them.

I copied just the setup files and got the error:

>  WARN probe_rs::flashing::loader: No loadable segments were found in the ELF file.
>        Error No loadable segments were found in the ELF file.

This error probably does not happen if you clone the whole book repo (I guess then cargo uses the root config over the setup config), but adding "-C", "link-arg=-Tlink.x" to the `rustflags` prevents this error.