### PR TITLE
updated cargo config

### DIFF
--- a/mdbook/src/05-meet-your-software/.cargo/config.toml
+++ b/mdbook/src/05-meet-your-software/.cargo/config.toml
@@ -5,4 +5,5 @@ target = "thumbv7em-none-eabihf"
 runner = "probe-rs run --chip nRF52833_xxAA"
 rustflags = [
   "-C", "linker=rust-lld",
+  "-C", "link-arg=-Tlink.x",
 ]

--- a/mdbook/src/06-hello-world/.cargo/config.toml
+++ b/mdbook/src/06-hello-world/.cargo/config.toml
@@ -5,4 +5,5 @@ target = "thumbv7em-none-eabihf"
 runner = "probe-rs run --chip nRF52833_xxAA"
 rustflags = [
   "-C", "linker=rust-lld",
+  "-C", "link-arg=-Tlink.x",
 ]

--- a/mdbook/src/07-registers/.cargo/config.toml
+++ b/mdbook/src/07-registers/.cargo/config.toml
@@ -5,4 +5,5 @@ target = "thumbv7em-none-eabihf"
 runner = "probe-rs run --chip nRF52833_xxAA"
 rustflags = [
   "-C", "linker=rust-lld",
+  "-C", "link-arg=-Tlink.x",
 ]

--- a/mdbook/src/08-led-roulette/.cargo/config.toml
+++ b/mdbook/src/08-led-roulette/.cargo/config.toml
@@ -5,4 +5,5 @@ target = "thumbv7em-none-eabihf"
 runner = "probe-rs run --chip nRF52833_xxAA"
 rustflags = [
   "-C", "linker=rust-lld",
+  "-C", "link-arg=-Tlink.x",
 ]

--- a/mdbook/src/10-uart/.cargo/config.toml
+++ b/mdbook/src/10-uart/.cargo/config.toml
@@ -5,4 +5,5 @@ target = "thumbv7em-none-eabihf"
 runner = "probe-rs run --chip nRF52833_xxAA"
 rustflags = [
   "-C", "linker=rust-lld",
+  "-C", "link-arg=-Tlink.x",
 ]

--- a/mdbook/src/11-i2c/.cargo/config.toml
+++ b/mdbook/src/11-i2c/.cargo/config.toml
@@ -5,4 +5,5 @@ target = "thumbv7em-none-eabihf"
 runner = "probe-rs run --chip nRF52833_xxAA"
 rustflags = [
   "-C", "linker=rust-lld",
+  "-C", "link-arg=-Tlink.x",
 ]

--- a/mdbook/src/12-led-compass/.cargo/config.toml
+++ b/mdbook/src/12-led-compass/.cargo/config.toml
@@ -5,4 +5,5 @@ target = "thumbv7em-none-eabihf"
 runner = "probe-rs run --chip nRF52833_xxAA"
 rustflags = [
   "-C", "linker=rust-lld",
+  "-C", "link-arg=-Tlink.x",
 ]

--- a/mdbook/src/13-punch-o-meter/.cargo/config.toml
+++ b/mdbook/src/13-punch-o-meter/.cargo/config.toml
@@ -5,4 +5,5 @@ target = "thumbv7em-none-eabihf"
 runner = "probe-rs run --chip nRF52833_xxAA"
 rustflags = [
   "-C", "linker=rust-lld",
+  "-C", "link-arg=-Tlink.x",
 ]

--- a/mdbook/src/14-snake-game/.cargo/config.toml
+++ b/mdbook/src/14-snake-game/.cargo/config.toml
@@ -5,4 +5,5 @@ target = "thumbv7em-none-eabihf"
 runner = "probe-rs run --chip nRF52833_xxAA"
 rustflags = [
   "-C", "linker=rust-lld",
+  "-C", "link-arg=-Tlink.x",
 ]

--- a/mdbook/src/appendix/3-mag-calibration/.cargo/config.toml
+++ b/mdbook/src/appendix/3-mag-calibration/.cargo/config.toml
@@ -5,4 +5,5 @@ target = "thumbv7em-none-eabihf"
 runner = "probe-rs run --chip nRF52833_xxAA"
 rustflags = [
   "-C", "linker=rust-lld",
+  "-C", "link-arg=-Tlink.x",
 ]

--- a/mdbook/src/serial-setup/.cargo/config.toml
+++ b/mdbook/src/serial-setup/.cargo/config.toml
@@ -5,4 +5,5 @@ target = "thumbv7em-none-eabihf"
 runner = "probe-rs run --chip nRF52833_xxAA"
 rustflags = [
   "-C", "linker=rust-lld",
+  "-C", "link-arg=-Tlink.x",
 ]


### PR DESCRIPTION
Follow up to #17: updating the rest of the cargo configs in the book. 

I think @BartMassey is probably right that this fix is needed due to platform differences (I am on Windows and without this I get an error). If this change causes an error for anyone else maybe it is best to just mention this as a potential fix in the [General troubleshooting](https://docs.rust-embedded.org/discovery-mb2/appendix/1-general-troubleshooting/index.html#general-troubleshooting) section of the book.