### PR TITLE
Make syntax compatible with epub generation

### DIFF
--- a/mdbook/book.toml
+++ b/mdbook/book.toml
@@ -6,3 +6,5 @@ language = "en"
 
 [output.html]
 git-repository-url = "https://github.com/rust-embedded/discovery-mb2/"
+
+[output.epub]

--- a/mdbook/book.toml
+++ b/mdbook/book.toml
@@ -6,5 +6,3 @@ language = "en"
 
 [output.html]
 git-repository-url = "https://github.com/rust-embedded/discovery-mb2/"
-
-[output.epub]

--- a/mdbook/src/02-requirements/README.md
+++ b/mdbook/src/02-requirements/README.md
@@ -20,7 +20,7 @@ Also, to follow this material you'll need:
   [0]: https://microbit.org/buy/
 
   <p align="center">
-  <img title="micro:bit" src="../assets/microbit-v2.jpg" width="500"/>
+  <img title="micro:bit" src="../assets/microbit-v2.jpg" width="500" />
   </p>
 
   There are several versions of the `V2` board
@@ -32,7 +32,7 @@ Also, to follow this material you'll need:
   that the cable supports data transfer, as some cables only support charging devices.
 
   <p align="center">
-  <img title="micro-B USB cable" src="../assets/usb-cable.jpg" width="500">
+  <img title="micro-B USB cable" src="../assets/usb-cable.jpg" width="500" />
   </p>
 
   > **NOTE** Some micro:bit kits ship with such cables.  USB cables used with other mobile

--- a/mdbook/src/04-meet-your-hardware/README.md
+++ b/mdbook/src/04-meet-your-hardware/README.md
@@ -5,7 +5,7 @@ Let's get familiar with the hardware we'll be working with.
 ## micro:bit
 
 <p align="center">
-<img title="micro:bit" src="../assets/microbit-v2.jpg">
+<img title="micro:bit" src="../assets/microbit-v2.jpg" />
 </p>
 
 Here are some of the many components on the board:

--- a/mdbook/src/07-registers/README.md
+++ b/mdbook/src/07-registers/README.md
@@ -44,7 +44,7 @@ direction. Hook an LED up "forwards" and light comes out. Hook it up "backwards"
 happens.
 
 <p align="center">
-<img class="white_bg" height=180 title="LED circuit" src="https://upload.wikimedia.org/wikipedia/commons/c/c9/LED_circuit.svg">
+<img class="white_bg" height="180" title="LED circuit" src="https://upload.wikimedia.org/wikipedia/commons/c/c9/LED_circuit.svg" />
 </p>
 
 Luckily for us, the microcontroller's pins are connected such that we can drive the LEDs the right

--- a/mdbook/src/08-led-roulette/README.md
+++ b/mdbook/src/08-led-roulette/README.md
@@ -3,7 +3,7 @@
 Alright, let's build a "real" application. The goal is to get to this display of spinning lights:
 
 <p align="center">
-<video src="../assets/roulette_fast.mp4" width="500" loop autoplay/>
+<video src="../assets/roulette_fast.mp4" width="500" loop="true" autoplay="true"/>
 </p>
 
 Since working with the LED pins separately is quite annoying (especially if you have to use

--- a/mdbook/src/08-led-roulette/the-challenge.md
+++ b/mdbook/src/08-led-roulette/the-challenge.md
@@ -3,13 +3,13 @@
 You are now well armed to face our challenge! Again, your application should look like this:
 
 <p align="center">
-<video src="../assets/roulette_fast.mp4" width="500" loop autoplay/>
+<video src="../assets/roulette_fast.mp4" width="500" loop="true" autoplay="true"/>
 </p>
 
 If you can't exactly see what's happening here it is in a much slower version:
 
 <p align="center">
-<video src="../assets/roulette_slow.mp4" width="500" loop autoplay/>
+<video src="../assets/roulette_slow.mp4" width="500" loop="true" autoplay="true"/>
 </p>
 
 If you need a hint, `templates/solution.rs` provides a mostly-filled-out chunk of code to finish. I

--- a/mdbook/src/09-serial-communication/README.md
+++ b/mdbook/src/09-serial-communication/README.md
@@ -2,7 +2,7 @@
 
 <a href="https://en.wikipedia.org/wiki/File:Serial_port.jpg">
 <p align="center">
-<img height="240" title="Standard serial port connector DE-9" src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Serial_port.jpg/800px-Serial_port.jpg"/>
+<img height="240" title="Standard serial port connector DE-9" src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Serial_port.jpg/800px-Serial_port.jpg" />
 </p>
 </a>
 

--- a/mdbook/src/09-serial-communication/nix-tooling.md
+++ b/mdbook/src/09-serial-communication/nix-tooling.md
@@ -75,7 +75,7 @@ This tells `minicom` to open the serial device at `/dev/ttyACM0` and set its
 baud rate to 115200. A text-based user interface (TUI) will pop out.
 
 <p align="center">
-<img title="minicom" src="../assets/minicom.png">
+<img title="minicom" src="../assets/minicom.png" />
 </p>
 
 You can now send data using the keyboard! Go ahead and type something. Note that

--- a/mdbook/src/11-i2c/README.md
+++ b/mdbook/src/11-i2c/README.md
@@ -26,7 +26,7 @@ implementation allows sending bytes to a particular device, with other devices c
 wires ignoring this communication.
 
 <p align="center">
-<img class="white_bg" height="360" title="I2C bus" src="https://upload.wikimedia.org/wikipedia/commons/c/c9/LED_circuit.svg" />
+<img class="white_bg" height="360" title="I2C bus" src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/04/I2C_controller-target.svg/640px-I2C_controller-target.svg.png" />
 </p>
 
 I2C uses a *controller*/*target* model: the controller is the device that *starts* and drives the

--- a/mdbook/src/11-i2c/README.md
+++ b/mdbook/src/11-i2c/README.md
@@ -26,7 +26,7 @@ implementation allows sending bytes to a particular device, with other devices c
 wires ignoring this communication.
 
 <p align="center">
-<img class="white_bg" height=360 title="I2C bus" src="https://upload.wikimedia.org/wikipedia/commons/0/04/I2C_controller-target.svg" />
+<img class="white_bg" height="360" title="I2C bus" src="https://upload.wikimedia.org/wikipedia/commons/c/c9/LED_circuit.svg" />
 </p>
 
 I2C uses a *controller*/*target* model: the controller is the device that *starts* and drives the

--- a/mdbook/src/11-i2c/the-general-protocol.md
+++ b/mdbook/src/11-i2c/the-general-protocol.md
@@ -8,7 +8,7 @@ communication between several devices. Let's see how it works using examples:
 If the Controller wants to send data to the Target:
 
 <p align="center">
-  <img class="white_bg" height=360 title="I2C bus" src="https://upload.wikimedia.org/wikipedia/commons/0/04/I2C_controller-target.svg" />
+  <img class="white_bg" height="360" title="I2C bus" src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/04/I2C_controller-target.svg/640px-I2C_controller-target.svg.png" />
 </p>
 
 1. Controller: Broadcast START
@@ -27,7 +27,7 @@ If the Controller wants to send data to the Target:
 If the controller wants to read data from the target:
 
 <p align="center">
-<img class="white_bg" height=360 title="I2C bus" src="https://upload.wikimedia.org/wikipedia/commons/0/04/I2C_controller-target.svg" />
+<img class="white_bg" height="360" title="I2C bus" src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/04/I2C_controller-target.svg/640px-I2C_controller-target.svg.png" />
 </p>
 
 1. C: Broadcast START

--- a/mdbook/src/12-led-compass/the-challenge.md
+++ b/mdbook/src/12-led-compass/the-challenge.md
@@ -7,7 +7,7 @@ We'll use the `atan2` function. This function returns an angle in the `-PI` to `
 graphic below shows how this angle is measured:
 
 <p align="center">
-<img class="white_bg" title="atan2" src="https://upload.wikimedia.org/wikipedia/commons/0/03/Atan2_60.svg">
+<img class="white_bg" title="atan2" src="https://upload.wikimedia.org/wikipedia/commons/0/03/Atan2_60.svg" />
 </p>
 
 Although not explicitly shown, in this graph the X axis points to the right and the Y axis points

--- a/mdbook/src/appendix/3-mag-calibration/README.md
+++ b/mdbook/src/appendix/3-mag-calibration/README.md
@@ -32,7 +32,7 @@ The way the user does the calibration is shown in this video from the C++ versio
 initial printing — the calibration starts about halfway through.)
 
 <p align="center">
-<video src="https://video.microbit.org/support/compass+calibration.mp4" loop autoplay>
+<video src="https://video.microbit.org/support/compass+calibration.mp4" loop="true" autoplay="true" />
 </p>
 
 You have to tilt the micro:bit until all the LEDs on the LED matrix light up. The blinking cursor


### PR DESCRIPTION
I was trying to build epub to read on my kindle. Anyway. Here are some fixes which are not compatible with more strict ebook checking.

After this book successfully builds with `mdbook-epub` and doesn't contain errors.

To build epub, add `[output.epub]` to `book.toml` and `cargo install mdbook-epub`