### PR TITLE
- Corrected arch linux dependency for `libunwind`, which was

### DIFF
--- a/mdbook/src/03-setup/linux.md
+++ b/mdbook/src/03-setup/linux.md
@@ -22,7 +22,7 @@ $ sudo dnf install gdb minicom libunwind-devel
 > **NOTE** `arm-none-eabi-gdb` is the GDB command you'll use to debug your ARM
 > Cortex-M programs.
 ``` console
-$ sudo pacman -S arm-none-eabi-gdb minicom libunwind-dev
+$ sudo pacman -S arm-none-eabi-gdb minicom libunwind
 ```
 
 ## Other distros


### PR DESCRIPTION
  inappropriately named `libunwind-dev`

#28 