### PR TITLE
Clarify magnetometer documentation reference in Chapter 11

### DIFF
--- a/mdbook/src/11-i2c/the-challenge.md
+++ b/mdbook/src/11-i2c/the-challenge.md
@@ -7,6 +7,5 @@ as well as "accelerometer" and then print the corresponding sensor data
 in response. This time no template code will be provided since all you need
 is already provided in the [UART](../10-uart/index.md) and this chapter. However, here are a few clues:
 
-- You might be interested in `core::str::from_utf8` to convert the bytes in the buffer to a `&str`, since we need to compare with `"magnetometer"` and `"accelerometer"`.
-- You will (obviously) have to read the documentation of the magnetometer API, however
-  it's more or less equivalent to the accelerometer one
+-   You might be interested in `core::str::from_utf8` to convert the bytes in the buffer to a `&str`, since we need to compare with `"magnetometer"` and `"accelerometer"`.
+-   You will have to read the documentation for the magnetometer API and functionality. While the `lsm303agr` crate provides the API interface, the [LSM303AGR datasheet](https://www.st.com/resource/en/datasheet/lsm303agr.pdf) details the sensor's magnetic field measurement parameters. See pages 13-15 for sensor characteristics and, importantly, pages 66-67 for the output register format.


### PR DESCRIPTION
- Reference LSM303AGR datasheet with page numbers
- Distinguish between crate API docs and hardware datasheet

Fixes #20