### PR TITLE
add the link path for .md file

### DIFF
--- a/mdbook/src/DOWNLOAD.md
+++ b/mdbook/src/DOWNLOAD.md
@@ -1,4 +1,4 @@
 # 📥 download ePUB version of the book
 
 
-You can download the EPUB version of this book here:  [Download](Rust Embedded MB2 Discovery Book.epub)
+You can download the EPUB version of this book here:  [Download](/discovery-mb2/Rust%20Embedded%20MB2%20Discovery%20Book.epub)


### PR DESCRIPTION
the download link for the Download.md file is give `You can download the EPUB version of this book here: [Download](Rust Embedded MB2 Discovery Book.epub)` instead of  `You can download the EPUB version of this book here: [Download](/discovery-mb2/Rust%20Embedded%20MB2%20Discovery%20Book.epub) ` or `Rust%20Embedded%20MB2%20Discovery%20Book.epub` as the case maybe. this as a result of how html `<a herf >` works