### PR TITLE
Add section Embedded Setup back into chapter 5

### DIFF
--- a/mdbook/src/05-meet-your-software/.cargo/config.toml
+++ b/mdbook/src/05-meet-your-software/.cargo/config.toml
@@ -5,4 +5,5 @@ target = "thumbv7em-none-eabihf"
 runner = "probe-rs run --chip nRF52833_xxAA"
 rustflags = [
   "-C", "linker=rust-lld",
+  "-C", "link-arg=-Tlink.x",
 ]

--- a/mdbook/src/SUMMARY.md
+++ b/mdbook/src/SUMMARY.md
@@ -11,6 +11,7 @@
     - [micro:bit v2](04-meet-your-hardware/microbit-v2.md)
     - [Rust Embedded terminology](04-meet-your-hardware/terminology.md)
 - [Meet your software](05-meet-your-software/README.md)
+    - [Embedded Setup](05-meet-your-software/embedded-setup.md)
     - [Build it](05-meet-your-software/build-it.md)
     - [Flash it](05-meet-your-software/flash-it.md)
     - [Debug it](05-meet-your-software/debug-it.md)


### PR DESCRIPTION
The section about embedded setup seems to have fallen out of the book `SUMMARY.md` and is therefore not included in the rendering of the book.

The necessary link argument is only specified in the top workspace `.cargo/config.toml` and this PR duplicates that line to have a complete reference to include in the chapter.

Changes:
- Add Embedded Setup to SUMMARY
- Add 'link-arg' from workspace to 'config.toml' for completeness