### PR TITLE
Switch buttons for led activation to match text.

### DIFF
--- a/mdbook/src/08-inputs-and-outputs/examples/polling-led-toggle.rs
+++ b/mdbook/src/08-inputs-and-outputs/examples/polling-led-toggle.rs
@@ -36,9 +36,9 @@ fn main() -> ! {
             // Stay in current state until something is pressed.
             (false, false) => (),
             // Change to on state.
-            (false, true) => row1.set_high().unwrap(),
+            (true, false) => row1.set_high().unwrap(),
             // Change to off state.
-            (true, false) => row1.set_low().unwrap(),
+            (false, true) => row1.set_low().unwrap(),
             // Stay in current state until something is released.
             (true, true) => (),
         }


### PR DESCRIPTION
The led should turn on when button A is pressed and off when button B is pressed. The existing code does the opposite, turning on when button B is pressed and off when button A is pressed.

This was tested on a recently bought MicroBit v2.