### PR TITLE
docs: use correct chapter number

### DIFF
--- a/mdbook/src/11-uart/send-a-single-byte.md
+++ b/mdbook/src/11-uart/send-a-single-byte.md
@@ -4,7 +4,7 @@ Our first task will be to send a single byte from the microcontroller to the com
 serial connection.
 
 In order to do that we will use the following snippet (this one is already in
-`10-uart/examples/send-byte.rs`):
+`11-uart/examples/send-byte.rs`):
 
 ``` rust
 {{#include examples/send-byte.rs}}


### PR DESCRIPTION
The path mentioned in UART chapter of the book references a directory named `10-uart`, but the chapter is now number 11.
