### PR TITLE
fixed button press polling to report only changes

### DIFF
--- a/mdbook/src/08-inputs-and-outputs/README.md
+++ b/mdbook/src/08-inputs-and-outputs/README.md
@@ -15,3 +15,5 @@ Let's now apply this knowledge to reading the state of Button A by checking if t
 ```rust
 {{#include examples/button-a-bsp.rs}}
 ```
+
+We spin looking at the button state, and report anytime that state changes.

--- a/mdbook/src/08-inputs-and-outputs/examples/button-a-bsp.rs
+++ b/mdbook/src/08-inputs-and-outputs/examples/button-a-bsp.rs
@@ -13,12 +13,19 @@ fn main() -> ! {
     let board = Board::take().unwrap();
 
     let mut button_a = board.buttons.button_a;
+    let mut button_state = false;
 
     loop {
         if button_a.is_low().unwrap() {
-            rprintln!("Button A pressed");
+            if button_state == false {
+                button_state = true;
+                rprintln!("Button A pressed");
+            }
         } else {
-            rprintln!("Button A not pressed");
+            if button_state == true {
+                button_state = false;
+                rprintln!("Button A not pressed");
+            }
         }
     }
 }


### PR DESCRIPTION
In the chapter dealing with buttons, we were spinning and printing the button state very rapidly in one example. This fixes that.