### PR TITLE
Update macos.md

### DIFF
--- a/mdbook/src/03-setup/macos.md
+++ b/mdbook/src/03-setup/macos.md
@@ -5,8 +5,8 @@ All the tools can be installed using [Homebrew]:
 [Homebrew]: http://brew.sh/
 
 ``` console
-$ # Arm GCC debugger
-$ brew install arm-none-eabi-gdb
+$ # GDB debugger - The version in brew is built for all architectures including all of the ARM embedded cores
+$ brew install gdb
 
 $ # Minicom
 $ brew install minicom


### PR DESCRIPTION
Neither the specific arm-eabi-gdb nor gdb-multiarch are required on macOS as of macOS 26 (2 October 2025)  The base gdb in brew is built with:

(gdb) show configuration
This GDB was configured as follows:
   configure --host=aarch64-apple-darwin25.0.0 --target=x86_64-apple-darwin20
	     --enable-targets=all

And works without either the arm-eabi stuff or gdb-multiarch installed. 