### PR TITLE
Update broken link to product specification

### DIFF
--- a/mdbook/src/04-meet-your-hardware/microbit-v2.md
+++ b/mdbook/src/04-meet-your-hardware/microbit-v2.md
@@ -23,7 +23,7 @@ short for radio frequency.  If we search through the documentation of the chip l
 [aQFN73]: https://en.wikipedia.org/wiki/Flat_no-leads_package
 [Nordic Semiconductor]: https://www.nordicsemi.com/
 [product page]: https://www.nordicsemi.com/products/nrf52833
-[product specification]: https://infocenter.nordicsemi.com/pdf/nRF52833_PS_v1.3.pdf
+[product specification]: https://docs.nordicsemi.com/bundle/nRF52833-PS/resource/nRF52833_PS_v1.3.pdf
 
 - The `N52` is the MCU's series, indicating that there are other `nRF52` MCUs
 - The `833` is the part code


### PR DESCRIPTION
I just discovery that i was reading the old version. Re-reading i found the same broken link that in https://github.com/rust-embedded/discovery/pull/604 so I port that fix to this repo.