### PR TITLE
Enable rtt in embed for chapter 11

### DIFF
--- a/mdbook/src/11-uart/Embed.toml
+++ b/mdbook/src/11-uart/Embed.toml
@@ -2,10 +2,10 @@
 chip = "nrf52833_xxAA"
 
 [default.reset]
-halt_afterwards = true
+halt_afterwards = false
 
 [default.rtt]
-enabled = false
+enabled = true
 
 [default.gdb]
-enabled = true
+enabled = false


### PR DESCRIPTION
Reading [11-uart/receive-a-single-byte](https://docs.rust-embedded.org/discovery-mb2/11-uart/receive-a-single-byte.html) I found that the `examples/receive-byte.rs` don't work (compile, flash, but don't start the `rtt`) because [`Embed.toml` in that chapter](https://github.com/rust-embedded/discovery-mb2/blob/main/mdbook/src/11-uart/Embed.toml) has the  `rtt` disabled.

It's should be: 
```
[default.general]
chip = "nrf52833_xxAA"

[default.reset]
halt_afterwards = false

[default.rtt]
enabled = true

[default.gdb]
enabled = false
```

And this should be the same for the rest of the examples in this chapter.
