### PR TITLE
Remove confusing "mod serial_setup" from example

### DIFF
--- a/mdbook/src/11-uart/reverse-a-string.md
+++ b/mdbook/src/11-uart/reverse-a-string.md
@@ -24,7 +24,6 @@ use microbit::{
     hal::uarte::{Baudrate, Parity},
 };
 
-mod serial_setup;
 use serial_setup::UartePort;
 
 #[entry]


### PR DESCRIPTION
From what little I understand, this `mod` is unnecessary because you can't import it without changing the path, and besides, it's already in the `Cargo.toml` file for this chapter (which is probably already being used for the example since it includes the dependencies).

