### PR TITLE
add links to wikipedia

### DIFF
--- a/mdbook/src/11-uart/README.md
+++ b/mdbook/src/11-uart/README.md
@@ -1,9 +1,11 @@
 # UART
 
-Our microcontroller (like most) has UART ("Universal Asynchronous Receiver/Transmitter)
+Our microcontroller (like most) has [UART] ("Universal Asynchronous Receiver/Transmitter)
 peripherals. There are two kinds of UART peripheral on the MB2: the older `UART` and the newer
 `UARTE` ("UART with Easy DMA").  We will use a `UARTE` peripheral to talk to our hardware serial
 port.
 
 Throughout this chapter, we'll use serial communication to exchange information between the
 microcontroller and your computer.
+
+[UART]: https://en.wikipedia.org/wiki/Universal_asynchronous_receiver-transmitter

--- a/mdbook/src/12-i2c/README.md
+++ b/mdbook/src/12-i2c/README.md
@@ -18,7 +18,7 @@ widely used in digital sensors.
 The micro:bit board we are using has two motion sensors in it: an accelerometer and a magnetometer.
 Both of these sensors are packaged into a single component and can be accessed via an I2C bus.
 
-I2C is pronounced "EYE-SQUARED-CEE" and stands for Inter-Integrated Circuit. I2C is a *synchronous*
+[I2C] is pronounced "EYE-SQUARED-CEE" and stands for Inter-Integrated Circuit. I2C is a *synchronous*
 serial *bus* communication protocol: it uses two lines to exchange data: a data line (SDA) and a
 clock line (SCL). The clock line is used to synchronize the communication. Synchronous serial can
 run faster and more reliably than async serial. I2C devices have *bus addresses*: the hardware
@@ -46,3 +46,5 @@ controller ends the communication.
 
 The clock line determines how fast data can be exchanged. The MB2 I2C interface can operate at
 speeds of 100, 250 or 400 Kbps. With other devices even faster modes are possible.
+
+[I2C]: https://en.wikipedia.org/wiki/I2C


### PR DESCRIPTION
Similar to the [serial chapter](https://github.com/rust-embedded/discovery-mb2/blob/main/mdbook/src/10-serial-port/README.md?plain=1#L48), I've added links to Wikipedia in the introduction to `I2C` and `UART`.